### PR TITLE
Fix addProductToCart so local-storage can save multiple products

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,11 +1,18 @@
+import { getLocalStorage } from "./utils.mjs";
 import { setLocalStorage } from "./utils.mjs";
 import ProductData from "./ProductData.mjs";
 
 const dataSource = new ProductData("tents");
 
 function addProductToCart(product) {
-  setLocalStorage("so-cart", product);
+  //If there's no local storage property array will be enforced to utilize push function later
+  let cart = getLocalStorage("so-cart") || [];
+
+  cart.push(product);
+
+  setLocalStorage("so-cart",cart);
 }
+
 // add to cart button event handler
 async function addToCartHandler(e) {
   const product = await dataSource.findProductById(e.target.dataset.id);


### PR DESCRIPTION
# Fix addProductToCart so local-storage can save multiple products

Enforce local-storage to receive a list so multiple products can be saved into shopping cart

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/test case covered (non-breaking change which adds functionality/coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a setting update (anything non related to test case implementation and/or documentation)

# What files or classes have been modified/updated/created? -if apply-

- Update product.js > Add getLocalStorage import from utils.mjs to retrieve local storage data

# What methods/test cases have been modified/updated/created? -if apply-

- product.addProductToCart(product) > Start by calling so-cart property, in case is null enforce void array creation. Push product to array result and update/set local storage so-cart property

# Checklist:

- [X] I updated my local branch to have the lastest update from main branch ("master") before starting this new branch -**preferred rebase**-
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing tests cases pass locally with my changes
- [ ] New and existing tests cases pass in pipeline with my changes

# Picture attachment of test execution results:
![image](https://github.com/user-attachments/assets/842dda9d-c147-4f1a-aca7-4be8d642096c)